### PR TITLE
Handle cloudfront-forwarded-port header too

### DIFF
--- a/src/CloudfrontProxies.php
+++ b/src/CloudfrontProxies.php
@@ -18,7 +18,7 @@ class CloudfrontProxies
      */
     public function handle($request, Closure $next)
     {
-        if ($request->header('cloudfront-forwarded-proto')) {
+        if ($request->header('cloudfront-forwarded-proto') || $request->header('cloudfront-forwarded-port')) {
             $this->loadTrustedProxies($request);
             $this->setCloudfrontHeaders($request);
         }
@@ -48,6 +48,11 @@ class CloudfrontProxies
     protected function setCloudfrontHeaders($request)
     {
         $headers = $request->headers;
-        $headers->add(['x-forwarded-proto' => $headers->get('cloudfront-forwarded-proto')]);
+        if($request->header('cloudfront-forwarded-proto')) {
+            $headers->add(['x-forwarded-proto' => $headers->get('cloudfront-forwarded-proto')]);
+        }
+        if($request->header('cloudfront-forwarded-port')) {
+            $headers->add(['x-forwarded-port' => $headers->get('cloudfront-forwarded-port')]);
+        }
     }
 }

--- a/tests/CloudfrontProxiesTest.php
+++ b/tests/CloudfrontProxiesTest.php
@@ -155,6 +155,92 @@ class CloudfrontProxiesTest extends BaseTestCase
     /**
      * @test
      */
+    public function it_rewrites_port_headers()
+    {
+        $request = new Request(
+            [], // query
+            [], // request
+            [], // attributes
+            [], // cookies
+            [], // files
+            [
+                'HTTP_CLOUDFRONT_FORWARDED_PORT' => '443',
+            ], // server
+            null // content
+        );
+        $middleware = new CloudfrontProxies;
+        $mock = Mockery::mock(Guzzle::class);
+        $response = new Response(200, [
+            'Content-Type' => 'application/json'
+        ], json_encode([
+                    'prefixes' => [
+                        [
+                            'ip_prefix' => '127.0.0.1/16',
+                            'region' => 'GLOBAL',
+                            'service' => 'CLOUDFRONT'
+                        ]
+                    ]
+                ]));
+        $mock->shouldReceive('get')
+            ->with('https://ip-ranges.amazonaws.com/ip-ranges.json')
+            ->once()
+            ->andReturn($response);
+        app()->instance(Guzzle::class, $mock);
+
+        $middleware->handle($request, function () {
+        });
+
+        // Verify that trusted proxies got properly set
+        $this->assertEquals('443', $request->header('x-forwarded-port'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_rewrites_proto_and_port_headers()
+    {
+        $request = new Request(
+            [], // query
+            [], // request
+            [], // attributes
+            [], // cookies
+            [], // files
+            [
+                'HTTP_CLOUDFRONT_FORWARDED_PORT' => '443',
+                'HTTP_CLOUDFRONT_FORWARDED_PROTO' => 'https',
+            ], // server
+            null // content
+        );
+        $middleware = new CloudfrontProxies;
+        $mock = Mockery::mock(Guzzle::class);
+        $response = new Response(200, [
+            'Content-Type' => 'application/json'
+        ], json_encode([
+                    'prefixes' => [
+                        [
+                            'ip_prefix' => '127.0.0.1/16',
+                            'region' => 'GLOBAL',
+                            'service' => 'CLOUDFRONT'
+                        ]
+                    ]
+                ]));
+        $mock->shouldReceive('get')
+            ->with('https://ip-ranges.amazonaws.com/ip-ranges.json')
+            ->once()
+            ->andReturn($response);
+        app()->instance(Guzzle::class, $mock);
+
+        $middleware->handle($request, function () {
+        });
+
+        // Verify that trusted proxies got properly set
+        $this->assertEquals('https', $request->header('x-forwarded-proto'));
+        $this->assertEquals('443', $request->header('x-forwarded-port'));
+    }
+
+    /**
+     * @test
+     */
     public function we_properly_get_https_routes()
     {
         $request = new Request(


### PR DESCRIPTION
I have a use case where I need to _also_ need the forwarded port to be set.
For an app we're developing, [Ziggy](https://github.com/tighten/ziggy) is still pulling the port number resulting in a base URL like `https://myapp.com:80`

